### PR TITLE
chore: create a release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,19 @@
+name: "tagged-release"
+
+on:
+  create
+
+jobs:
+  tagged-release:
+    # Don't run on releases/tags/* which causes recursive behaviour
+    if: startsWith(github.ref, 'refs/tags/')
+    name: "Tagged Release"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GH_TOKEN }}"
+          automatic_release_tag: "${{ github.ref_name }}"
+          prerelease: false
+          files: "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,13 @@ jobs:
     name: "Tagged Release"
     runs-on: "ubuntu-latest"
 
+    permissions:
+      contents: write
+
     steps:
-      - uses: "marvinpinto/action-automatic-releases@latest"
+      - uses: marvinpinto/action-automatic-releases@latest
         with:
-          repo_token: "${{ secrets.GH_TOKEN }}"
-          automatic_release_tag: "${{ github.ref_name }}"
+          repo_token: ${{ github.token }}
+          automatic_release_tag: ${{ github.ref_name }}
           prerelease: false
           files: "*"


### PR DESCRIPTION
Workflow to create release when new tag is pushed.

This is because to create a see-js (eye-js equivalent) I want to use the github release API